### PR TITLE
fix mount path typo

### DIFF
--- a/7-state-persistence.md
+++ b/7-state-persistence.md
@@ -78,7 +78,7 @@ spec:
   - image: nginx
     name: app
     volumeMounts:
-      - mountPath: "/data/app/config"
+      - mountPath: "/var/app/config"
         name: configpvc
     resources: {}
   volumes:


### PR DESCRIPTION
Fix mount path for persistent volume in chapter 7 according to
```Mount the Persistent Volume Claim from a new Pod named app with the path /var/app/config. The Pod uses the image nginx.```